### PR TITLE
Add codeowners for automate reviewer assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# All repo
+* @turbaszek
+
+# Docs stuff
+README.md @sharanf
+CODE_OF_CONDUCT.md @sharanf
+CONTRIBUTING.md @sharanf
+docs/ @sharanf

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # All repo
-* @turbaszek
+* @turbaszek @michalslowikowski00
 
 # Docs stuff
 README.md @sharanf


### PR DESCRIPTION
> Code owners are automatically requested for review when someone opens a pull request that modifies code that they own. 
https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners

I think we may try this feature. Currently contributors are not able to request review (unless they ping a committer). 

I tried to create some basic rules but I'm happy to get any suggestions!